### PR TITLE
Fix bounds check in interprocedural overflow sample

### DIFF
--- a/SVFIR/overflow/interprocedural.c
+++ b/SVFIR/overflow/interprocedural.c
@@ -4,11 +4,13 @@
 #define BUFFER_SIZE 10
 void handle_client_request(char *input,
                            int index) {
-	int buffer[BUFFER_SIZE] = { 0 };
-	if (index >= 0)
-		buffer[index] = input[index];
-	else
-		printf("ERR: Array index is negative\n");
+        int buffer[BUFFER_SIZE] = { 0 };
+        if (index >= 0 && index < BUFFER_SIZE)
+                buffer[index] = input[index];
+        else if (index < 0)
+                printf("ERR: Array index is negative\n");
+        else
+                printf("ERR: Array index out of bounds\n");
 }
 void process_socket_data(char *input,
                          int index) {


### PR DESCRIPTION
## Summary
- fix out-of-bounds write in interprocedural.c example

## Testing
- `./SVFIR/compile.sh SVFIR/overflow/interprocedural.c` *(fails: opt not found)*

------
https://chatgpt.com/codex/tasks/task_b_684114d82348832fb68eed84dad0f193